### PR TITLE
fix false positive error on git checkout from pip

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,9 @@ class SoclessPackager {
       if (this.abortOnPackagingErrors){
         const countErrorNewLines = errorText.split('\n').length
 
-        if(!errorText.includes("ERROR:") && countErrorNewLines < 2 && errorText.toLowerCase().includes('git clone')){
+        if(!errorText.includes("ERROR:") && 
+           ((countErrorNewLines < 2 && errorText.toLowerCase().includes('git clone')) ||
+             (countErrorNewLines < 3 && errorText.toLowerCase().includes('git checkout')))) {
           // Ignore false positive due to pip git clone printing to stderr
         } else if(errorText.toLowerCase().includes('warning') && !errorText.toLowerCase().includes('error')){
           // Ignore warnings


### PR DESCRIPTION
pip doing a git clone on a pinned version will do a checkout , which increases the number of lines outputted

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
